### PR TITLE
Improve battle flow

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -25,16 +25,39 @@ class Battle {
     this.isWildBattle = isWildBattle;
     this.itemSelected = 0;
     this.skillEffectProgress = null;
-    this.skillEffectUpdateCounter = 0;
     this.enemySkillSelected = null;
     this.enemySkillEffectProgress = null;
-    this.enemySkillEffectUpdateCounter = 0;
     this.playerMonsterOpacity = 1;
     this.enemyMonsterOpacity = 1;
     this.currentMessage = '';
     this.setNextAlivePlayerMonster();
     this.setNextAliveEnemyMonster();
     this.price = price;
+  }
+
+  update(deltaTime) {
+    if (!this.active) return;
+
+    if (this.transitionProgress < this.transitionDuration) {
+      this.transitionProgress += deltaTime;
+      if (this.transitionProgress > this.transitionDuration) {
+        this.transitionProgress = this.transitionDuration;
+      }
+    }
+
+    if (this.skillEffectProgress !== null) {
+      this.skillEffectProgress += deltaTime / 300;
+      if (this.skillEffectProgress >= 1) {
+        this.skillEffectProgress = null;
+      }
+    }
+
+    if (this.enemySkillEffectProgress !== null) {
+      this.enemySkillEffectProgress += deltaTime / 300;
+      if (this.enemySkillEffectProgress >= 1) {
+        this.enemySkillEffectProgress = null;
+      }
+    }
   }
 
   setNextAlivePlayerMonster() {

--- a/js/main.js
+++ b/js/main.js
@@ -601,27 +601,36 @@ function update(deltaTime) {
     PreStage = 5;
   }
 
-  const activeBattle = (wildBattle && wildBattle.active) ||
-    npcs.some((npc) => npc.battle.active);
+  let activeBattle = null;
+  if (wildBattle && wildBattle.active) {
+    activeBattle = wildBattle;
+  }
+  npcs.forEach((npc) => {
+    if (npc.battle.active) {
+      activeBattle = npc.battle;
+    }
+  });
 
 
   if (!activeBattle && !messageBox.visible) {
-      const moveSpeed = 100; // Pixels per second
-      const moveAmount = moveSpeed * (deltaTime / 1000);
-        
-      if (keysPressed['ArrowUp']) {
-        window.player.move("up", moveAmount, window.map);
-      }
-      if (keysPressed['ArrowDown']) {
-        window.player.move("down", moveAmount, window.map);
-      }
-      if (keysPressed['ArrowLeft']) {
-        window.player.move("left", moveAmount, window.map);
-      }
-      if (keysPressed['ArrowRight']) {
-        window.player.move("right", moveAmount, window.map);
-      }
+    const moveSpeed = 100; // Pixels per second
+    const moveAmount = moveSpeed * (deltaTime / 1000);
+
+    if (keysPressed['ArrowUp']) {
+      window.player.move("up", moveAmount, window.map);
     }
+    if (keysPressed['ArrowDown']) {
+      window.player.move("down", moveAmount, window.map);
+    }
+    if (keysPressed['ArrowLeft']) {
+      window.player.move("left", moveAmount, window.map);
+    }
+    if (keysPressed['ArrowRight']) {
+      window.player.move("right", moveAmount, window.map);
+    }
+  } else if (activeBattle) {
+    activeBattle.update(deltaTime);
+  }
 
 }
 
@@ -812,41 +821,6 @@ function draw(ctx) {
       }
 
       if (activeBattle) {
-        // Draw the active battle
-        // Draw the active battle
-        if (activeBattle && activeBattle.skillEffectProgress !== null) {
-          activeBattle.skillEffectUpdateCounter++;
-
-          // Update skillEffectProgress every N frames
-          const updateFrequency = 5; // Adjust this value to control the speed of the effect animation
-
-          if (activeBattle.skillEffectUpdateCounter % updateFrequency === 0) {
-            activeBattle.skillEffectProgress += 0.05;
-          }
-
-          if (activeBattle.skillEffectProgress >= 1) {
-            activeBattle.skillEffectProgress = null;
-            activeBattle.skillEffectUpdateCounter = 0;
-          }
-        }
-
-        // Update the enemy's skill effect progress
-          if (activeBattle.enemySkillEffectProgress !== null) {
-            activeBattle.enemySkillEffectUpdateCounter++;
-
-            // Update enemySkillEffectProgress every N frames
-            const updateFrequency = 5; // Adjust this value to control the speed of the effect animation
-
-            if (activeBattle.enemySkillEffectUpdateCounter % updateFrequency === 0) {
-              activeBattle.enemySkillEffectProgress += 0.05;
-            }
-
-            if (activeBattle.enemySkillEffectProgress >= 1) {
-              activeBattle.enemySkillEffectProgress = null;
-              activeBattle.enemySkillEffectUpdateCounter = 0;
-            }
-          }
-
         activeBattle.draw(ctx);
 
       } else {


### PR DESCRIPTION
## Summary
- smooth battle animations by adding a new `update` method in `Battle`
- call `update` from the main game loop and simplify draw logic

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68421bb0acd4832da1a8c53c4e3e43c3